### PR TITLE
Add burn the state (bts) token list

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -62,5 +62,9 @@
   "tokenlist.zerion.eth": {
     "name": "Zerion Explore",
     "homepage": ""
+  },
+  "burnthestate.eth": {
+    "name": "burn the state",
+    "homepage": ""
   }
 }

--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -7,6 +7,10 @@
     "name": "Aave Token List",
     "homepage": ""
   },
+  "burnthestate.eth": {
+    "name": "burn the state",
+    "homepage": ""
+  },
   "defi.cmc.eth": {
     "name": "CMC DeFi",
     "homepage": ""
@@ -61,10 +65,6 @@
   },
   "tokenlist.zerion.eth": {
     "name": "Zerion Explore",
-    "homepage": ""
-  },
-  "burnthestate.eth": {
-    "name": "burn the state",
     "homepage": ""
   }
 }

--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -9,7 +9,7 @@
   },
   "burnthestate.eth": {
     "name": "burn the state",
-    "homepage": ""
+    "homepage": "burnthestate.eth"
   },
   "defi.cmc.eth": {
     "name": "CMC DeFi",


### PR DESCRIPTION
This PR adds the "burn the state" token list to tokenlist.org. Link to the ens address is `burnthestate.eth` and tokenlist.org token list page is [https://tokenlists.org/token-list?url=burnthestate.eth](https://tokenlists.org/token-list?url=burnthestate.eth).

**Screenshot**

![image](https://user-images.githubusercontent.com/3393723/92299801-ac30e200-ef23-11ea-9c83-f07495f4102d.png)
