### PR TITLE
Fix GitHub spelling

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -28,7 +28,7 @@ export default function Footer() {
       <span>A Uniswap Project</span>
       <Nav>
         <a href="https://uniswap.org/docs/v2/">Docs</a>
-        <a href="https://github.com/uniswap">Github</a>
+        <a href="https://github.com/uniswap">GitHub</a>
         <a href="https://discord.gg/XErMcTq">Discord</a>
         <a href="https://app.uniswap.org">App</a>
       </Nav>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -105,7 +105,7 @@ export default function Header({ back }) {
             src="https://raw.githubusercontent.com/feathericons/feather/master/icons/github.svg"
             alt="github icon"
           />
-          <span style={{ color: 'white' }}>Github</span>
+          <span style={{ color: 'white' }}>GitHub</span>
         </ButtonLink>
       </Nav>
     </StyledHeader>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.