### PR TITLE
token-lists: Update URI for Wrapped Tokens

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -115,9 +115,9 @@
     "name": "UMA",
     "homepage": ""
   },
-  "wrapped.tokensoft.eth": {
+  "https://wrapped.com/tokenlist.json": {
     "name": "Wrapped Tokens",
-    "homepage": ""
+    "homepage": "https://wrapped.com/"
   },
   "https://yearn.science/static/tokenlist.json": {
     "name": "Yearn",


### PR DESCRIPTION
Hi there! We maintain the wrapped.tokensoft.eth token list. This PR points it to our website instead of our ENS.

Hope you all are having a nice summer and staying healthy. :) Thanks!