### PR TITLE
feat: use bgd tokenlist for aave instead of outdated one pointing to *.link

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -3,7 +3,7 @@
     "name": "1inch",
     "homepage": ""
   },
-  "tokenlist.aave.eth": {
+  "https://raw.githubusercontent.com/bgd-labs/aave-tokenlist/main/tokenlist.json": {
     "name": "Aave Token List",
     "homepage": ""
   },


### PR DESCRIPTION
The aave tokenlist has been outdated for a while.
This pr alters the list to point to a maintained tokenlist github repo.