### PR TITLE
Updating Optimism token list name

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -84,8 +84,8 @@
     "homepage": ""
   },
   "https://static.optimism.io/optimism.tokenlist.json": {
-    "name": "Optimism",
-    "homepage": "https://optimism.io/"
+    "name": "Superchain",
+    "homepage": "https://optimism.io/superchain"
   },
   "https://app.tryroll.com/tokens.json": {
     "name": "Roll Social Money",


### PR DESCRIPTION
Updating name of the Optimism token list to the Superchain token list as this will be the unified list used for OP Chains in the Superchain. 

https://github.com/ethereum-optimism/ethereum-optimism.github.io/pull/343