### PR TITLE
Add ZiGVerse TokenList with ZiG and ZiGT (Polygon zkEVM)

### DIFF
--- a/lists/zigverse/zig-tokenlist.json
+++ b/lists/zigverse/zig-tokenlist.json
@@ -1,0 +1,26 @@
+{
+  "name": "ZiGVerse TokenList",
+  "logoURI": "https://cdn.jsdelivr.net/gh/kmafutah/zigverse-tokenlist@main/logo/zigverse.png",
+  "keywords": ["zigverse", "zig", "zigt", "gold", "stablecoin", "pan-african"],
+  "timestamp": "2025-07-16T12:00:00+00:00",
+  "version": { "major": 1, "minor": 1, "patch": 0 },
+  "tokens": [
+    {
+      "chainId": 1101,
+      "address": "0x9d485613b48f6617E90B4Dfe664Bf52127572BBa",
+      "name": "ZiG Token",
+      "symbol": "ZiG",
+      "decimals": 18,
+      "logoURI": "https://cdn.jsdelivr.net/gh/kmafutah/zigverse-tokenlist@main/logo/zig.png"
+    },
+    {
+      "chainId": 1101,
+      "address": "0xEbcF9FF0868F57F08d86e6a94889A0DECB99D43b",
+      "name": "ZiGT Stablecoin",
+      "symbol": "ZiGT",
+      "decimals": 18,
+      "logoURI": "https://cdn.jsdelivr.net/gh/kmafutah/zigverse-tokenlist@main/logo/zigt.png"
+    }
+  ]
+}
+

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
   },
   "devDependencies": {
     "prettier": "^2.1.1"
-  }
+  },
+  "description": "![Token lists](https://github.com/Uniswap/tokenlists-org/blob/master/public/card.png?raw=true)",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC"
 }

--- a/tokenlist.schema.json
+++ b/tokenlist.schema.json
@@ -1,0 +1,1 @@
+Redirecting to /@uniswap/token-lists@1.0.0-beta.34/test/schema/tokenlist.schema.json


### PR DESCRIPTION
List URL:
https://cdn.jsdelivr.net/gh/kmafutah/zigverse-tokenlist@main/zig-tokenlist.json

List Name:
ZiGVerse TokenList

Homepage:
https://zigverse.github.io

Description:
ZiGVerse is a Pan-African smart monetary ecosystem including:
- ZiG (gold-backed hard asset token)
- ZiGT (ZWL-pegged stablecoin for payments)

Both tokens are currently deployed on Polygon zkEVM (chainId: 1101) and will later migrate to Base and BSC due to infrastructure deprecation. Hosted via GitHub + jsDelivr CDN. Maintained by @kmafutah.
