### PR TITLE
Add Qi Energy Token List (Base 8453)

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -134,5 +134,9 @@
   "tokenlist.zerion.eth": {
     "name": "Zerion Explore",
     "homepage": ""
+  },
+  "https://raw.githubusercontent.com/n4y-ai/tokenQI/main/qi-energy.tokenlist.json": {
+    "name": "Qi Energy Token List",
+    "homepage": "https://n4y.ai"
   }
 }


### PR DESCRIPTION
Adds Qi Energy token list to the catalog.\n\nList URL: https://raw.githubusercontent.com/n4y-ai/tokenQI/main/qi-energy.tokenlist.json\nProject: https://github.com/n4y-ai/tokenQI\nLogo: https://raw.githubusercontent.com/n4y-ai/tokenQI/main/qi_energy.svg\n\nValidated against schema: https://uniswap.org/tokenlist.schema.json