### PR TITLE
Add Fondart Token List (Base Mainnet)

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -3,6 +3,10 @@
     "name": "1inch",
     "homepage": ""
   },
+  "https://raw.githubusercontent.com/disemino/fondart/main/fondart-tokenlist.json": {
+    "name": "Fondart Token List",
+    "homepage": "https://www.fondart.xyz"
+  },
   "tokenlist.aave.eth": {
     "name": "Aave Token List",
     "homepage": ""
@@ -135,4 +139,11 @@
     "name": "Zerion Explore",
     "homepage": ""
   }
+}
+{
+  name: "Fondart Token List",
+  url: "https://raw.githubusercontent.com/disemino/fondart/main/fondart-tokenlist.json",
+  logoURI: "https://www.fondart.xyz/fondart.png",
+  keywords: ["art","utility","base","amoarte"],
+  verified: false
 }


### PR DESCRIPTION
- List name: Fondart Token List
- URL (RAW): https://raw.githubusercontent.com/disemino/fondart/main/fondart-tokenlist.json
- Maintainer homepage: https://www.fondart.xyz
- Chain(s): Base Mainnet (chainId 8453)
- Purpose: Utility token list for the Amoarte.net ecosystem (art certification, rewards, access)
- Validation: conforms to @uniswap/token-lists schema (AJV validated)