### PR TITLE
Adding COTI Token list

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -134,5 +134,9 @@
   "tokenlist.zerion.eth": {
     "name": "Zerion Explore",
     "homepage": ""
+  },
+  "https://raw.githubusercontent.com/coti-io/coti-token-list/refs/heads/main/CotiTokenList.json": {
+    "name": "Coti Core Token List",
+    "homepage": "https://coti.io"
   }
 }


### PR DESCRIPTION
- List name: Coti Core Token List
- URL (RAW): https://raw.githubusercontent.com/coti-io/coti-token-list/refs/heads/main/CotiTokenList.json
- Maintainer homepage: https://coti.io/
- Chain(s): Ethereum Mainnet (chainId 1), Coti Mainnet (chainId 2632500)
- Purpose: Officially supported COTI tokens
- Validation: conforms to @uniswap/token-lists schema (AJV validated)