### PR TITLE
Add Grail token list

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -63,6 +63,10 @@
     "name": "Gemini Token List",
     "homepage": "https://www.gemini.com/"
   },
+  "https://assets.grail.xyz/tokens.json": {
+    "name": "Grail",
+    "homepage": "https://grail.xyz"
+  },
   "t2crtokens.eth": {
     "name": "Kleros T2CR",
     "homepage": ""


### PR DESCRIPTION
Adds [Grail](https://grail.xyz)'s token list to the registry.

- **List URL**: https://assets.grail.xyz/tokens.json
- **Homepage**: https://grail.xyz
- **Network**: Base (chainId 8453)
- **Tokens**: 9 currently live; list is backend-published and auto-updates as new tokens are registered

Grail tokens represent ownership of PSA-graded cards stored in a fully insured vault.

The list validates against the [token list standard](https://github.com/Uniswap/token-lists) and is currently at version 1.0.9.