### PR TITLE
Fetch ENS-hosted lists via eth.limo instead of the wispy-bird worker proxy

### DIFF
--- a/src/pages/list.js
+++ b/src/pages/list.js
@@ -36,7 +36,7 @@ export function getURLFromQuery(query) {
   if (query?.startsWith('https://')) {
     return query
   } else if (query?.endsWith('.eth')) {
-    return `http://${query}.link`
+    return `https://${query}.limo`
   } else {
     return null
   }

--- a/src/utils/useMultiFetch.ts
+++ b/src/utils/useMultiFetch.ts
@@ -10,8 +10,8 @@ export function getListURLFromListID(listID: string): string {
   if (listID.startsWith('https://')) {
     return listID
   } else if (listID?.endsWith('.eth')) {
-    // proxy http urls through a CF worker
-    return `https://wispy-bird-88a7.uniswap.workers.dev/?url=${`http://${listID}.link`}`
+    // eth.limo gateway serves ENS content with CORS headers, no proxy needed
+    return `https://${listID}.limo`
   } else {
     throw Error(`Unrecognized listId ${listID}`)
   }


### PR DESCRIPTION
## Why

`wispy-bird-88a7.uniswap.workers.dev` is an open HTTP proxy (it fetches any `?url=` target) deployed in Aug 2020 solely because `*.eth.link` lacked usable CORS headers. Security wants to decommission it (1.2M req/mo, largely abuse). eth.limo serves ENS content with `access-control-allow-origin: *`, so the site can fetch lists directly.

## What's already broken

The proxy path currently returns **403 for every ENS list** on the site, so ENS lists appear to be broken in production today. Via eth.limo, 11 of 13 return 200 with valid JSON. The two failures (`tokenlist.dharma.eth`, `tokenlist.zerion.eth`) are dead ENS names that fail through the proxy as well — candidates for removal from the registry in a follow-up.

## Changes

- `getListURLFromListID`: `https://<name>.eth.limo` instead of the worker proxy
- `getURLFromQuery` (list page): same
- The list-info external link now points at eth.limo, a nicer human-facing URL than the worker

Companion PR in Uniswap/data switches the tokenlists scraper the same way. Once both land, the worker can be killed (or first restricted to `*.eth.link` targets during a deprecation window for third-party users who hardcode it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)